### PR TITLE
Added additional methods to access postbacks in the Registration

### DIFF
--- a/PostbackInfo.cs
+++ b/PostbackInfo.cs
@@ -1,0 +1,98 @@
+﻿/* Software License Agreement (BSD License)
+ * 
+ * Copyright (c) 2010-2011, Rustici Software, LLC
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Rustici Software, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+
+namespace RusticiSoftware.HostedEngine.Client
+{
+  public class PostbackInfo
+  {
+    private string _registrationId;
+    private string _url;
+    private string _registrationResultsAuthType;
+    private string _learnerLogin;
+    private string _learnerPassword;
+
+
+    /// <summary>
+    /// Inflate launch info object from passed in xml element
+    /// </summary>
+    /// <param name="launchInfoElem"></param>
+    /// <param name="postbackInfoElem"></param>
+    public PostbackInfo(XmlElement postbackInfoElem)
+    {
+      this.RegistrationId = postbackInfoElem.GetAttribute("regid");
+
+      this.Url = ((XmlElement)postbackInfoElem.GetElementsByTagName("url")[0]).InnerText;
+      //this.Url = postbackInfoElem.GetAttribute("url");
+      this.LearnerLogin = ((XmlElement)postbackInfoElem.GetElementsByTagName("login")[0]).InnerText;
+      this.LearnerPassword = ((XmlElement)postbackInfoElem.GetElementsByTagName("password")[0]).InnerText;
+      this.RegistrationResultsAuthType = ((XmlElement)postbackInfoElem.GetElementsByTagName("authtype")[0]).InnerText;
+    }
+
+    /// <summary>
+    /// Unique Identifier for this registration
+    /// </summary>
+    public string RegistrationId
+    {
+      get { return _registrationId; }
+      private set { _registrationId = value; }
+    }
+
+    public string Url
+    {
+      get { return _url; }
+      private set { _url = value; }
+    }
+
+
+    public string RegistrationResultsAuthType
+    {
+      get { return _registrationResultsAuthType; }
+      private set { _registrationResultsAuthType = value; }
+    }
+
+    public string LearnerLogin
+    {
+      get { return _learnerLogin; }
+      private set { _learnerLogin = value; }
+    }
+
+    public string LearnerPassword
+    {
+      get { return _learnerPassword; }
+      private set { _learnerPassword = value; }
+    }
+
+
+
+  }
+}

--- a/RegistrationData.cs
+++ b/RegistrationData.cs
@@ -32,230 +32,231 @@ using System.Xml;
 
 namespace RusticiSoftware.HostedEngine.Client
 {
+  /// <summary>
+  /// Data class to hold high-level Registration Data
+  /// </summary>
+  public class RegistrationData
+  {
+    private string _registrationId;
+    private string _courseId;
+    private string _courseTitle;
+    private string _lastCourseVersionLaunched;
+    private string _learnerId;
+    private string _learnerFirstName;
+    private string _learnerLastName;
+    private string _email;
+
+    private DateTime _createDate;
+    private DateTime? _firstAccessDate;
+    private DateTime? _lastAccessDate;
+    private DateTime? _completedDate;
+
+    private List<InstanceData> _instances;
+
+
     /// <summary>
-    /// Data class to hold high-level Registration Data
+    /// Constructor which takes an XML node as returned by the web service.
     /// </summary>
-    public class RegistrationData
+    /// <param name="regDataEl"></param>
+    public RegistrationData(XmlElement registrationElem)
     {
-        private string _registrationId;
-        private string _courseId;
-        private string _courseTitle;
-        private string _lastCourseVersionLaunched;
-        private string _learnerId;
-        private string _learnerFirstName;
-        private string _learnerLastName;
-        private string _email;
+      this.RegistrationId = registrationElem.Attributes["id"].Value;
 
-        private DateTime _createDate;
-        private DateTime? _firstAccessDate;
-        private DateTime? _lastAccessDate;
-        private DateTime? _completedDate;
+      this.CourseId = registrationElem.Attributes["courseid"].Value;
 
-        private List<InstanceData> _instances;
+      this.CourseTitle = ((XmlElement)registrationElem
+                      .GetElementsByTagName("courseTitle")[0])
+                      .InnerText;
 
+      this.LastCourseVersionLaunched = ((XmlElement)registrationElem
+                      .GetElementsByTagName("lastCourseVersionLaunched")[0])
+                      .InnerText;
 
-        /// <summary>
-        /// Constructor which takes an XML node as returned by the web service.
-        /// </summary>
-        /// <param name="regDataEl"></param>
-        public RegistrationData(XmlElement registrationElem)
-        {
-            this.RegistrationId = registrationElem.Attributes["id"].Value;
+      this.LearnerId = ((XmlElement)registrationElem
+                      .GetElementsByTagName("learnerId")[0])
+                      .InnerText;
 
-            this.CourseId = registrationElem.Attributes["courseid"].Value;
+      this.LearnerFirstName = ((XmlElement)registrationElem
+                      .GetElementsByTagName("learnerFirstName")[0])
+                      .InnerText;
 
-            this.CourseTitle = ((XmlElement)registrationElem
-                            .GetElementsByTagName("courseTitle")[0])
-                            .InnerText;
+      this.LearnerLastName = ((XmlElement)registrationElem
+                      .GetElementsByTagName("learnerLastName")[0])
+                      .InnerText;
 
-            this.LastCourseVersionLaunched = ((XmlElement)registrationElem
-                            .GetElementsByTagName("lastCourseVersionLaunched")[0])
-                            .InnerText;
+      this.Email = ((XmlElement)registrationElem
+                      .GetElementsByTagName("email")[0])
+                      .InnerText;
 
-            this.LearnerId = ((XmlElement)registrationElem
-                            .GetElementsByTagName("learnerId")[0])
-                            .InnerText;
+      this.CreateDate = DateTime.Parse(((XmlElement)registrationElem
+                      .GetElementsByTagName("createDate")[0])
+                      .InnerText);
 
-            this.LearnerFirstName = ((XmlElement)registrationElem
-                            .GetElementsByTagName("learnerFirstName")[0])
-                            .InnerText;
+      this.FirstAccessDate = Utils.ParseNullableDate(((XmlElement)registrationElem
+                      .GetElementsByTagName("firstAccessDate")[0])
+                      .InnerText);
 
-            this.LearnerLastName = ((XmlElement)registrationElem
-                            .GetElementsByTagName("learnerLastName")[0])
-                            .InnerText;
+      this.LastAccessDate = Utils.ParseNullableDate(((XmlElement)registrationElem
+                      .GetElementsByTagName("lastAccessDate")[0])
+                      .InnerText);
 
-            this.Email = ((XmlElement)registrationElem
-                            .GetElementsByTagName("email")[0])
-                            .InnerText;
+      this.CompletedDate = Utils.ParseNullableDate(((XmlElement)registrationElem
+                      .GetElementsByTagName("completedDate")[0])
+                      .InnerText);
 
-            this.CreateDate = DateTime.Parse(((XmlElement)registrationElem
-                            .GetElementsByTagName("createDate")[0])
-                            .InnerText);
-
-            this.FirstAccessDate = Utils.ParseNullableDate(((XmlElement)registrationElem
-                            .GetElementsByTagName("firstAccessDate")[0])
-                            .InnerText);
-
-            this.LastAccessDate = Utils.ParseNullableDate(((XmlElement)registrationElem
-                            .GetElementsByTagName("lastAccessDate")[0])
-                            .InnerText);
-
-            this.CompletedDate = Utils.ParseNullableDate(((XmlElement)registrationElem
-                            .GetElementsByTagName("completedDate")[0])
-                            .InnerText);
-
-            this.Instances = InstanceData.ConvertToInstanceDataList((XmlElement)registrationElem.GetElementsByTagName("instances")[0]);
-
-        }
-
-        /// <summary>
-        /// Helper method which takes the full XmlDocument as returned from the registration listing
-        /// web service and returns a List of RegistrationData objects.
-        /// </summary>
-        /// <param name="xmlDoc"></param>
-        /// <returns></returns>
-        public static List<RegistrationData> ConvertToRegistrationDataList(XmlDocument xmlDoc)
-        {
-            List<RegistrationData> allResults = new List<RegistrationData>();
-
-            XmlNodeList regDataList = xmlDoc.GetElementsByTagName("registration");
-            foreach (XmlElement regData in regDataList)
-            {
-                allResults.Add(new RegistrationData(regData));
-            }
-
-            return allResults;
-        }
-
-
-        
-        /// <summary>
-        /// Unique Identifier for this registration
-        /// </summary>
-        public string RegistrationId
-        {
-            get { return _registrationId; }
-            private set { _registrationId = value; }
-        }
-
-        /// <summary>
-        /// Course Identifier as specified at import-time
-        /// </summary>
-        public string CourseId
-        {
-            get { return _courseId; }
-            private set { _courseId = value; }
-        }
-
-        /// <summary>
-        /// The title of this course
-        /// </summary>
-        public string CourseTitle
-        {
-            get { return _courseTitle; }
-            private set { _courseTitle = value; }
-        }
-
-
-        /// <summary>
-        /// The last version of the course that was launched
-        /// </summary>
-        public string LastCourseVersionLaunched
-        {
-            get { return _lastCourseVersionLaunched; }
-            private set { _lastCourseVersionLaunched = value; }
-        }
-
-
-
-        /// <summary>
-        /// Learner Identifier as specified at import-time
-        /// </summary>
-        public string LearnerId
-        {
-            get { return _learnerId; }
-            private set { _learnerId = value; }
-        }
-
-
-        /// <summary>
-        /// Learner First Name as specified at import-time
-        /// </summary>
-        public string LearnerFirstName
-        {
-            get { return _learnerFirstName; }
-            private set { _learnerFirstName = value; }
-        }
-
-
-        /// <summary>
-        /// Learner Last Name as specified at import-time
-        /// </summary>
-        public string LearnerLastName
-        {
-            get { return _learnerLastName; }
-            private set { _learnerLastName = value; }
-        }
-
-
-        /// <summary>
-        /// Learner Email as specified at import-time
-        /// </summary>
-        public string Email
-        {
-            get { return _email; }
-            private set { _email = value; }
-        }
-
-
-        /// <summary>
-        /// Date in which the registration was created
-        /// </summary>
-        public DateTime CreateDate
-        {
-            get { return _createDate; }
-            private set { _createDate = value; }
-        }
-
-
-        /// <summary>
-        /// Date in which the registration was first accessed
-        /// </summary>
-        public DateTime? FirstAccessDate
-        {
-            get { return _firstAccessDate; }
-            private set { _firstAccessDate = value; }
-        }
-
-
-        /// <summary>
-        /// Date in which the registration was last accessed
-        /// </summary>
-        public DateTime? LastAccessDate
-        {
-            get { return _lastAccessDate; }
-            private set { _lastAccessDate = value; }
-        }
-
-
-        /// <summary>
-        /// Date in which the registration was completed
-        /// </summary>
-        public DateTime? CompletedDate
-        {
-            get { return _completedDate; }
-            private set { _completedDate = value; }
-        }
-
-
-        /// <summary>
-        /// List of Verions/Instances available for this course
-        /// </summary>
-        public List<InstanceData> Instances
-        {
-            get { return _instances; }
-            private set { _instances = value; }
-        }
+      this.Instances = InstanceData.ConvertToInstanceDataList((XmlElement)registrationElem.GetElementsByTagName("instances")[0]);
 
     }
+
+    /// <summary>
+    /// Helper method which takes the full XmlDocument as returned from the registration listing
+    /// web service and returns a List of RegistrationData objects.
+    /// </summary>
+    /// <param name="xmlDoc"></param>
+    /// <returns></returns>
+    public static List<RegistrationData> ConvertToRegistrationDataList(XmlDocument xmlDoc)
+    {
+      List<RegistrationData> allResults = new List<RegistrationData>();
+
+      XmlNodeList regDataList = xmlDoc.GetElementsByTagName("registration");
+      foreach (XmlElement regData in regDataList)
+      {
+        allResults.Add(new RegistrationData(regData));
+      }
+
+      return allResults;
+    }
+
+
+
+    /// <summary>
+    /// Unique Identifier for this registration
+    /// </summary>
+    public string RegistrationId
+    {
+      get { return _registrationId; }
+      private set { _registrationId = value; }
+    }
+
+    /// <summary>
+    /// Course Identifier as specified at import-time
+    /// </summary>
+    public string CourseId
+    {
+      get { return _courseId; }
+      private set { _courseId = value; }
+    }
+
+    /// <summary>
+    /// The title of this course
+    /// </summary>
+    public string CourseTitle
+    {
+      get { return _courseTitle; }
+      private set { _courseTitle = value; }
+    }
+
+
+    /// <summary>
+    /// The last version of the course that was launched
+    /// </summary>
+    public string LastCourseVersionLaunched
+    {
+      get { return _lastCourseVersionLaunched; }
+      private set { _lastCourseVersionLaunched = value; }
+    }
+
+
+
+    /// <summary>
+    /// Learner Identifier as specified at import-time
+    /// </summary>
+    public string LearnerId
+    {
+      get { return _learnerId; }
+      private set { _learnerId = value; }
+    }
+
+
+    /// <summary>
+    /// Learner First Name as specified at import-time
+    /// </summary>
+    public string LearnerFirstName
+    {
+      get { return _learnerFirstName; }
+      private set { _learnerFirstName = value; }
+    }
+
+
+    /// <summary>
+    /// Learner Last Name as specified at import-time
+    /// </summary>
+    public string LearnerLastName
+    {
+      get { return _learnerLastName; }
+      private set { _learnerLastName = value; }
+    }
+
+
+    /// <summary>
+    /// Learner Email as specified at import-time
+    /// </summary>
+    public string Email
+    {
+      get { return _email; }
+      private set { _email = value; }
+    }
+
+
+    /// <summary>
+    /// Date in which the registration was created
+    /// </summary>
+    public DateTime CreateDate
+    {
+      get { return _createDate; }
+      private set { _createDate = value; }
+    }
+
+
+    /// <summary>
+    /// Date in which the registration was first accessed
+    /// </summary>
+    public DateTime? FirstAccessDate
+    {
+      get { return _firstAccessDate; }
+      private set { _firstAccessDate = value; }
+    }
+
+
+    /// <summary>
+    /// Date in which the registration was last accessed
+    /// </summary>
+    public DateTime? LastAccessDate
+    {
+      get { return _lastAccessDate; }
+      private set { _lastAccessDate = value; }
+    }
+
+
+    /// <summary>
+    /// Date in which the registration was completed
+    /// </summary>
+    public DateTime? CompletedDate
+    {
+      get { return _completedDate; }
+      private set { _completedDate = value; }
+    }
+
+
+    /// <summary>
+    /// List of Verions/Instances available for this course
+    /// </summary>
+    public List<InstanceData> Instances
+    {
+      get { return _instances; }
+      private set { _instances = value; }
+    }
+
+  }
+
 }

--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -576,14 +576,14 @@ namespace RusticiSoftware.HostedEngine.Client
 	    /// <param name="applicationId">Your application id</param>
 	    /// <param name="registrationId">Specifies the registration id</param>
 	    /// <returns>PostackInfo</returns>
-	    public PostackInfo GetPostbackInfo(string applicationId, string registrationId)
+	    public PostbackInfo GetPostbackInfo(string applicationId, string registrationId)
 	    {
 			ServiceRequest request = new ServiceRequest(configuration);
 			request.Parameters.Add("appid", applicationId);
 			request.Parameters.Add("regId", registrationId);
 			XmlDocument response = request.CallService("rustici.registration.getPostbackInfo");
 			XmlElement postbackInfoElem = ((XmlElement)response.GetElementsByTagName("postbackinfo")[0]);
-			return new PostackInfo(postbackInfoElem);
+			return new PostbackInfo(postbackInfoElem);
 
 	    }
 	    /// <summary>

--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -96,60 +96,108 @@ namespace RusticiSoftware.HostedEngine.Client
         }
 
 
-        /// <summary>
-        /// Create a new Registration (Instance of a user taking a course)
-        /// </summary>
-        /// <param name="registrationId">Unique Identifier for the registration</param>
-        /// <param name="courseId">Unique Identifier for the course</param>
-        /// <param name="versionId">Optional versionID, if Int32.MinValue, latest course version is used.</param>
-        /// <param name="learnerId">Unique Identifier for the learner</param>
-        /// <param name="learnerFirstName">Learner's first name</param>
-        /// <param name="learnerLastName">Learner's last name</param>
-        /// <param name="resultsPostbackUrl">URL to which the server will post results back to</param>
-        /// <param name="authType">Type of Authentication used at results postback time</param>
-        /// <param name="postBackLoginName">If postback authentication is used, the logon name</param>
-        /// <param name="postBackLoginPassword">If postback authentication is used, the password</param>
-        /// <param name="resultsFormat">The Format of the results XML sent to the postback URL</param>
-        /// <param name="learnerTags">A comma separated list of learner tags to associate with this registration</param>
-        /// <param name="courseTags">A comma separated list of course tags to associate with this registration</param>
-        /// <param name="registrationTags">A comma separated list of tags to associate with this registration</param>
-        public void CreateRegistration(string registrationId, string courseId, int versionId, string learnerId,
-            string learnerFirstName, string learnerLastName, string resultsPostbackUrl,
-            RegistrationResultsAuthType authType, string postBackLoginName, string postBackLoginPassword,
-            RegistrationResultsFormat resultsFormat,
-            string learnerTags, string courseTags, string registrationTags)
-        {
-            ServiceRequest request = new ServiceRequest(configuration);
-            request.Parameters.Add("regid", registrationId);
-            request.Parameters.Add("courseid", courseId);
-            request.Parameters.Add("fname", learnerFirstName);
-            request.Parameters.Add("lname", learnerLastName);
-            request.Parameters.Add("learnerid", learnerId);
+      /// <summary>
+      /// Semantics: This method provides a way to update the postback settings for a registration created with the createRegistration call. If you wish to change an authenticated postback to an unauthenticated postback, please call this method with only a url specified.
+      /// </summary>
+      /// <param name="registrationId">Unique Identifier for the registration</param>
+      /// <param name="courseId">Unique Identifier for the course</param>
+      /// <param name="versionId">Optional versionID, if Int32.MinValue, latest course version is used.</param>
+      /// <param name="learnerId">Unique Identifier for the learner</param>
+      /// <param name="learnerFirstName">Learner's first name</param>
+      /// <param name="learnerLastName">Learner's last name</param>
+      /// <param name="resultsPostbackUrl">URL to which the server will post results back to</param>
+      /// <param name="authType">Type of Authentication used at results postback time</param>
+      /// <param name="postBackLoginName">If postback authentication is used, the logon name</param>
+      /// <param name="postBackLoginPassword">If postback authentication is used, the password</param>
+      /// <param name="resultsFormat">The Format of the results XML sent to the postback URL</param>
+      public void UpdatePostbackInfo(string applicationId, string registrationId, string resultsPostbackUrl,
+        string postBackLoginName, string postBackLoginPassword, RegistrationResultsAuthType authType,
+        RegistrationResultsFormat resultsFormat)
+		{
+			ServiceRequest request = new ServiceRequest(configuration);
+			request.Parameters.Add("appid", applicationId);
+			request.Parameters.Add("regid", registrationId);
+			request.Parameters.Add("postbackurl", resultsPostbackUrl);
 
-            // Required on this signature but not by the actual service
-            request.Parameters.Add("authtype", Enum.GetName(authType.GetType(), authType).ToLower());
-            request.Parameters.Add("resultsformat", Enum.GetName(resultsFormat.GetType(), resultsFormat).ToLower());
+			// Required on this signature but not by the actual service
+			request.Parameters.Add("authtype", Enum.GetName(authType.GetType(), authType).ToLower());
+			request.Parameters.Add("resultsformat", Enum.GetName(resultsFormat.GetType(), resultsFormat).ToLower());
 
-            // Optional:
-            if (!String.IsNullOrEmpty(resultsPostbackUrl))
-                request.Parameters.Add("postbackurl", resultsPostbackUrl);
-            if (!String.IsNullOrEmpty(postBackLoginName))
-                request.Parameters.Add("urlname", postBackLoginName);
-            if (!String.IsNullOrEmpty(postBackLoginPassword))
-                request.Parameters.Add("urlpass", postBackLoginPassword);
-            if (versionId != Int32.MinValue)
-                request.Parameters.Add("versionid", versionId);
+			// Optional:
+			if (!String.IsNullOrEmpty(postBackLoginName))
+				request.Parameters.Add("urlname", postBackLoginName);
+	        if (!String.IsNullOrEmpty(postBackLoginPassword))
+	        	request.Parameters.Add("urlpass", postBackLoginPassword);
 
-            // Optional tags
-            if (!String.IsNullOrEmpty(learnerTags))
-                request.Parameters.Add("learnerTags", learnerTags);
-            if (!String.IsNullOrEmpty(courseTags))
-                request.Parameters.Add("courseTags", courseTags);
-            if (!String.IsNullOrEmpty(registrationTags))
-                request.Parameters.Add("registrationTags", registrationTags);
+        	request.CallService("rustici.registration.updatePostbackInfo");
+      	}
 
-            request.CallService("rustici.registration.createRegistration");
-        }
+
+		public void UpdatePostbackInfo(string applicationId, string registrationId, string resultsPostbackUrl)
+		{
+			string postBackLoginName = String.Empty;
+	        string postBackLoginPassword = String.Empty;
+	        RegistrationResultsAuthType authType = RegistrationResultsAuthType.HTTPBASIC;
+	        RegistrationResultsFormat resultsFormat = RegistrationResultsFormat.FULL;
+
+	        UpdatePostbackInfo(applicationId, registrationId, resultsPostbackUrl, postBackLoginName, postBackLoginPassword, authType, resultsFormat);
+      	}
+
+
+      /// <summary>
+      /// Create a new Registration (Instance of a user taking a course)
+      /// </summary>
+      /// <param name="registrationId">Unique Identifier for the registration</param>
+      /// <param name="courseId">Unique Identifier for the course</param>
+      /// <param name="versionId">Optional versionID, if Int32.MinValue, latest course version is used.</param>
+      /// <param name="learnerId">Unique Identifier for the learner</param>
+      /// <param name="learnerFirstName">Learner's first name</param>
+      /// <param name="learnerLastName">Learner's last name</param>
+      /// <param name="resultsPostbackUrl">URL to which the server will post results back to</param>
+      /// <param name="authType">Type of Authentication used at results postback time</param>
+      /// <param name="postBackLoginName">If postback authentication is used, the logon name</param>
+      /// <param name="postBackLoginPassword">If postback authentication is used, the password</param>
+      /// <param name="resultsFormat">The Format of the results XML sent to the postback URL</param>
+      /// <param name="learnerTags">A comma separated list of learner tags to associate with this registration</param>
+      /// <param name="courseTags">A comma separated list of course tags to associate with this registration</param>
+      /// <param name="registrationTags">A comma separated list of tags to associate with this registration</param>
+      public void CreateRegistration(string registrationId, string courseId, int versionId, string learnerId,
+        string learnerFirstName, string learnerLastName, string resultsPostbackUrl,
+        RegistrationResultsAuthType authType, string postBackLoginName, string postBackLoginPassword,
+        RegistrationResultsFormat resultsFormat,
+        string learnerTags, string courseTags, string registrationTags)
+      {
+        ServiceRequest request = new ServiceRequest(configuration);
+        request.Parameters.Add("regid", registrationId);
+        request.Parameters.Add("courseid", courseId);
+        request.Parameters.Add("fname", learnerFirstName);
+        request.Parameters.Add("lname", learnerLastName);
+        request.Parameters.Add("learnerid", learnerId);
+
+              // Required on this signature but not by the actual service
+              request.Parameters.Add("authtype", Enum.GetName(authType.GetType(), authType).ToLower());
+              request.Parameters.Add("resultsformat", Enum.GetName(resultsFormat.GetType(), resultsFormat).ToLower());
+
+              // Optional:
+              if (!String.IsNullOrEmpty(resultsPostbackUrl))
+                  request.Parameters.Add("postbackurl", resultsPostbackUrl);
+              if (!String.IsNullOrEmpty(postBackLoginName))
+                  request.Parameters.Add("urlname", postBackLoginName);
+              if (!String.IsNullOrEmpty(postBackLoginPassword))
+                  request.Parameters.Add("urlpass", postBackLoginPassword);
+              if (versionId != Int32.MinValue)
+                  request.Parameters.Add("versionid", versionId);
+
+              // Optional tags
+              if (!String.IsNullOrEmpty(learnerTags))
+                  request.Parameters.Add("learnerTags", learnerTags);
+              if (!String.IsNullOrEmpty(courseTags))
+                  request.Parameters.Add("courseTags", courseTags);
+              if (!String.IsNullOrEmpty(registrationTags))
+                  request.Parameters.Add("registrationTags", registrationTags);
+
+              request.CallService("rustici.registration.createRegistration");
+          }
 
         //TODO: Other overrides of createRegistration....
 
@@ -521,5 +569,69 @@ namespace RusticiSoftware.HostedEngine.Client
             XmlElement launchInfoElem = ((XmlElement)response.GetElementsByTagName("launch")[0]);
             return new LaunchInfo(launchInfoElem);
         }
-    }
+
+    	/// <summary>
+	    ///  Get the postback attributes that were set in a createRegistration or updatePostbackInfo call.
+	    /// </summary>
+	    /// <param name="applicationId">Your application id</param>
+	    /// <param name="registrationId">Specifies the registration id</param>
+	    /// <returns>PostackInfo</returns>
+	    public PostackInfo GetPostbackInfo(string applicationId, string registrationId)
+	    {
+			ServiceRequest request = new ServiceRequest(configuration);
+			request.Parameters.Add("appid", applicationId);
+			request.Parameters.Add("regId", registrationId);
+			XmlDocument response = request.CallService("rustici.registration.getPostbackInfo");
+			XmlElement postbackInfoElem = ((XmlElement)response.GetElementsByTagName("postbackinfo")[0]);
+			return new PostackInfo(postbackInfoElem);
+
+	    }
+	    /// <summary>
+	    /// This method provides a way to test a URL for posting registration results back to, as they would be posted when using the postbackurl in the createRegistration call. When called, an example registration result will be posted to the URL given, or else an error will be reported regarding why the post failed.
+	    /// </summary>
+	    /// <param name="postbackUrl">Specifies a URL for which to post activity and status data in real time as the course is completed</param>
+	    /// <returns>Rsp containing result and status code</returns>
+	    public Rsp TestRegistrationPostUrl(string postbackUrl)
+	    {
+			return TestRegistrationPostUrl(postbackUrl, RegistrationResultsAuthType.HTTPBASIC, "placeholderUrlName", "placeholderUrlPassword", RegistrationResultsFormat.ACTIVITY);
+	    }
+
+	    /// <summary>
+	    /// This method provides a way to test a URL for posting registration results back to, as they would be posted when using the postbackurl in the createRegistration call. When called, an example registration result will be posted to the URL given, or else an error will be reported regarding why the post failed.
+	    /// </summary>
+	    /// <param name="postbackUrl">Specifies a URL for which to post activity and status data in real time as the course is completed</param>
+	    /// <param name="authType">Optional parameter to specify how to authorize against the given postbackurl, can be "form" or "httpbasic". If form authentication, the username and password for authentication are submitted as form fields "username" and "password", and the registration data as the form field "data". If httpbasic authentication is used, the username and password are placed in the standard Authorization HTTP header, and the registration data is the body of the message (sent as text/xml content type). This field is set to "form" by default.</param>
+	    /// <param name="urlname">You can optionally specify a login name to be used for credentials when posting to the URL specified in postbackurl</param>
+	    /// <param name="urlpass">If credentials for the postbackurl are provided, this must be included, it is the password to be used in authorizing the postback of data to the URL specified by postbackurl</param>
+	    /// <param name="resultsFormat">This parameter allows you to specify a level of detail in the information that is posted back while the course is being taken. It may be one of three values: "course" (course summary), "activity" (activity summary, or "full" (full detail), and is set to "course" by default. The information will be posted as xml, and the format of that xml is specified below under the method "getRegistrationResult"</param>
+	    /// <returns>Rsp containing result and status code</returns>
+	    public Rsp TestRegistrationPostUrl(string postbackUrl, RegistrationResultsAuthType authType, string urlname, string urlpass, RegistrationResultsFormat resultsFormat)
+	    {
+			ServiceRequest request = new ServiceRequest(configuration);
+			request.Parameters.Add("postbackurl", postbackUrl);
+
+			//Api call will fail without a placeholder username and password at least:
+			if (!String.IsNullOrEmpty(urlname))
+			{
+				request.Parameters.Add("name", urlname);
+			}
+			else
+			{
+				request.Parameters.Add("name", "placeholderLoginName");
+			}
+
+			if (!String.IsNullOrEmpty(urlpass))
+			{
+				request.Parameters.Add("password", urlpass);
+			}
+			else
+			{
+				request.Parameters.Add("password", "placeholderLoginPassword");
+			}
+
+			XmlDocument response = request.CallService("rustici.registration.testRegistrationPostUrl");
+			XmlElement rspElement = ((XmlElement)response.GetElementsByTagName("rsp")[0]);
+			return new Rsp(rspElement);
+	    }
+	}
 }

--- a/Rsp.cs
+++ b/Rsp.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+
+namespace RusticiSoftware.HostedEngine.Client
+{
+  public class Rsp
+  {
+    public Rsp(XmlElement rspElement)
+    {
+      this.Status = rspElement.GetAttribute("stat");
+      this.IsSuccess = rspElement.GetElementsByTagName("success").Count > 0;
+    }
+    private bool _isSuccess;
+    private string _status;
+    public string Status
+    {
+      get { return _status; }
+      private set { _status = value; }
+    }
+
+    public bool IsSuccess
+    {
+      get { return _isSuccess; }
+      private set
+      {
+        _isSuccess = value;
+      }
+    }
+  }
+}

--- a/RusticiSoftware.HostedEngine.Client.csproj
+++ b/RusticiSoftware.HostedEngine.Client.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="AsyncImportResult.cs" />
     <Compile Include="Configuration.cs" />
+    <Compile Include="PostbackInfo.cs" />
     <Compile Include="Rsp.cs" />
     <Compile Include="TaggingService.cs" />
     <Compile Include="CourseData.cs" />

--- a/RusticiSoftware.HostedEngine.Client.csproj
+++ b/RusticiSoftware.HostedEngine.Client.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="AsyncImportResult.cs" />
     <Compile Include="Configuration.cs" />
+    <Compile Include="Rsp.cs" />
     <Compile Include="TaggingService.cs" />
     <Compile Include="CourseData.cs" />
     <Compile Include="CustomWebClient.cs">


### PR DESCRIPTION
From the current version of this library the methods to access the postback are not available. I added them to the Registration Service as they are set in the one of the overloads for CreateRegistration.

Added the following methods to the Registration service class:
- GetPostbackInfo
- UpdatePostbackInfo
- DeletePostbackInfo
- TestRegistrationPostUrl

Added 2 classes for parsing xml
-PostbackInfo 
-Rsp (For viewing the results of TestRegistrationPostUrl)