### PR TITLE
Consider nuget

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -58,5 +58,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/README.txt
+++ b/README.txt
@@ -33,7 +33,10 @@ About:
 The SCORM Cloud .Net Library is a C# library intended to aid in the integration of the SCORM Cloud service API into .Net 2.0+ applications.  This library does not cover all possible SCORM Cloud service API calls, but it does cover the basics. Descriptions of the full API can be found here: http://cloud.scorm.com/EngineWebServices/doc/SCORMCloudAPI.html
 
 Using the Library:
-To use the library, open the project in Visual Studio and perform a build.  Then add a reference to the library dll to your integration project solution.
+This library can be found on Nuget at http://nuget.org/xxxxxx/yyyyyy.  You can add a reference to your project using "Manage NuGet Packages" inside Visual Studio.
+
+
+Another option is to build the project yourself, creating a .dll that you can add to your project.  Simply download this project's source code and build it.
 
 There is also a .Net Demo application available for download here: https://github.com/RusticiSoftware/SCORMCloud_NetDemoApp
 The demo app is meant to provide examples for how to use many of the basic library calls.


### PR DESCRIPTION
Why not put this library on Nuget?  It would be easier to incorporate this library by referencing Nuget packages, which most .Net developers use for every other library dependency.

It would also make versioning much easier, as you could release each update to the library as a new version.  Devs could get updates by pressing "Update," or stick with the versions they've always used.

It's really, really easy to publish to Nuget, too.  Install Nuget using the instructions provided at nuget.org, then go to your project's folder from a command prompt and type:

```
nuget pack RusticiSoftware.HostedEngine.Client.csproj
```

You'll get output like this:

```
MSBuild auto-detection: using msbuild version '14.0' from 'C:\Program Files (x86)\MSBuild\14.0\bin'.
Attempting to build package from 'RusticiSoftware.HostedEngine.Client.csproj'.
Packing files from 'C:\Users\cauthond\Desktop\SCORMCloud_NetLibrary\bin\Debug'.
Successfully created package 'C:\Users\cauthond\Desktop\SCORMCloud_NetLibrary\RusticiSoftware.HostedEngine.Client.1.2.1.0.nupkg'.
```

This will create a single file, `RusticiSoftware.HostedEngine.Client.1.2.1.0.nupkg`.  Create an account on nuget.org, then use their file uploader to upload this package.

![screenshot_020416_065323_am](https://cloud.githubusercontent.com/assets/148768/12815442/fdb8dda8-cb0b-11e5-8a4a-2863fa6f132e.jpg)

You can provide all of the meta information on the next screen - information like the name, version, description, license, author, etc.  These are all just text fields that you can update at any time.

And it's free!  :smile:
