### PR TITLE
Add Dictionary Option to GetLaunchUrl()

### DIFF
--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -555,6 +555,17 @@ namespace RusticiSoftware.HostedEngine.Client
             return request.ConstructUrl("rustici.registration.launch");
         }
 
+        /// <summary>
+        /// Gets the url to directly launch/view the course registration in a browser
+        /// </summary>
+        /// <param name="regid">Unique Identifier for the registration</param>
+        /// <param name="redirecturl">Upon exit, the url that the SCORM player will redirect to</param>
+        /// <param name="cssurl">Absolute url that points to a custom player style sheet</param>
+        /// <param name="saveDebugLogPointerUrl">Url that the server will postback a "pointer" url regarding</param>
+        /// <param name="player">Launch using alternative players like "modern"</param>
+        /// <param name="forceFrameset">Force course to launch using frameset (needed to play in mobile webview)</param>
+        /// <param name="parameters">Dictionary of parameters</param>
+        /// <returns>URL to launch</returns>
         public string GetLaunchUrl(Dictionary<string, object> parameters)
         {
             var request = new ServiceRequest(configuration);

--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -543,6 +543,11 @@ namespace RusticiSoftware.HostedEngine.Client
         /// a saved debug log that resides on s3</param>
         public string GetLaunchUrl(string registrationId, string redirectOnExitUrl, string cssUrl, string debugLogPointerUrl)
         {
+            return GetLaunchUrl(registrationId, redirectOnExitUrl, cssUrl, debugLogPointerUrl, new Dictionary<string, object>());
+        }
+
+        public string GetLaunchUrl(string registrationId, string redirectOnExitUrl, string cssUrl, string debugLogPointerUrl, Dictionary<string, object> parameters)
+        {
             ServiceRequest request = new ServiceRequest(configuration);
             request.Parameters.Add("regid", registrationId);
             if (!String.IsNullOrEmpty(redirectOnExitUrl))
@@ -551,26 +556,9 @@ namespace RusticiSoftware.HostedEngine.Client
                 request.Parameters.Add("cssurl", cssUrl);
             if (!String.IsNullOrEmpty(debugLogPointerUrl))
                 request.Parameters.Add("saveDebugLogPointerUrl", debugLogPointerUrl);
-
-            return request.ConstructUrl("rustici.registration.launch");
-        }
-
-        /// <summary>
-        /// Gets the url to directly launch/view the course registration in a browser
-        /// </summary>
-        /// <param name="regid">Unique Identifier for the registration</param>
-        /// <param name="redirecturl">Upon exit, the url that the SCORM player will redirect to</param>
-        /// <param name="cssurl">Absolute url that points to a custom player style sheet</param>
-        /// <param name="saveDebugLogPointerUrl">Url that the server will postback a "pointer" url regarding</param>
-        /// <param name="player">Launch using alternative players like "modern"</param>
-        /// <param name="forceFrameset">Force course to launch using frameset (needed to play in mobile webview)</param>
-        /// <param name="parameters">Dictionary of parameters</param>
-        /// <returns>URL to launch</returns>
-        public string GetLaunchUrl(Dictionary<string, object> parameters)
-        {
-            var request = new ServiceRequest(configuration);
-            foreach (var parameter in parameters)
-                request.Parameters.Add(parameter.Key, parameter.Value);
+            if (parameters != null)
+                foreach (var parameter in parameters)
+                    request.Parameters.Add(parameter.Key, parameter.Value);
 
             return request.ConstructUrl("rustici.registration.launch");
         }

--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -555,7 +555,7 @@ namespace RusticiSoftware.HostedEngine.Client
         /// <param name="debugLogPointerUrl">Url that the server will postback a "pointer" url regarding
         /// a saved debug log that resides on s3</param>
         /// <param name="parameters">Dictionary for any additional parameters that could be passed along in the request</param>
-        public string GetLaunchUrl(string registrationId, string redirectOnExitUrl, string cssUrl, string debugLogPointerUrl, Dictionary<string, object> parameters)
+        public string GetLaunchUrl(string registrationId, string redirectOnExitUrl, string cssUrl, string debugLogPointerUrl, IDictionary<string, object> parameters)
         {
             ServiceRequest request = new ServiceRequest(configuration);
             request.Parameters.Add("regid", registrationId);

--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -555,6 +555,15 @@ namespace RusticiSoftware.HostedEngine.Client
             return request.ConstructUrl("rustici.registration.launch");
         }
 
+        public string GetLaunchUrl(Dictionary<string, object> parameters)
+        {
+            var request = new ServiceRequest(configuration);
+            foreach (var parameter in parameters)
+                request.Parameters.Add(parameter.Key, parameter.Value);
+
+            return request.ConstructUrl("rustici.registration.launch");
+        }
+
         /// <summary>
         /// Returns list of launch info objects, each of which describe a particular launch,
         /// but note, does not include the actual history log for the launch. To get launch

--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -546,6 +546,15 @@ namespace RusticiSoftware.HostedEngine.Client
             return GetLaunchUrl(registrationId, redirectOnExitUrl, cssUrl, debugLogPointerUrl, new Dictionary<string, object>());
         }
 
+        /// <summary>
+        /// Gets the url to directly launch/view the course registration in a browser
+        /// </summary>
+        /// <param name="registrationId">Unique Identifier for the registration</param>
+        /// <param name="redirectOnExitUrl">Upon exit, the url that the SCORM player will redirect to</param>
+        /// <returns>URL to launch</returns>
+        /// <param name="debugLogPointerUrl">Url that the server will postback a "pointer" url regarding
+        /// a saved debug log that resides on s3</param>
+        /// <param name="parameters">Dictionary for any additional parameters that could be passed along in the request</param>
         public string GetLaunchUrl(string registrationId, string redirectOnExitUrl, string cssUrl, string debugLogPointerUrl, Dictionary<string, object> parameters)
         {
             ServiceRequest request = new ServiceRequest(configuration);


### PR DESCRIPTION
This allows me to add two additional parameters ("player" and "forceFrameset") without a lot of additional overloads, as well as make overloads unnecessary for future parameter additions.