### PR TITLE
Fix XML parsing for getCourseDetail

### DIFF
--- a/CourseDetail.cs
+++ b/CourseDetail.cs
@@ -63,8 +63,8 @@ namespace RusticiSoftware.HostedEngine.Client
             this.title = courseDetail.Attributes["title"].Value;
 
             versions = new List<CourseVersion>();
-            XmlNodeList versionList = courseDetail.GetElementsByTagName("versions");
-            foreach (XmlElement version in versionList)
+            XmlNodeList versionListItems = courseDetail.GetElementsByTagName("version");
+            foreach (XmlElement version in versionListItems)
                 this.versions.Add(new CourseVersion(version));
 
             tags = new List<string>();
@@ -75,13 +75,13 @@ namespace RusticiSoftware.HostedEngine.Client
             XmlNodeList learningStandardList = courseDetail.GetElementsByTagName("learningStandard");
             if (learningStandardList.Count > 0)
             {
-                this.learningStandard = learningStandardList.Item(0).Value;
+                this.learningStandard = learningStandardList.Item(0).FirstChild.Value;
             }
 
             XmlNodeList tincanActivityIdList = courseDetail.GetElementsByTagName("tincanActivivityId");
             if (tincanActivityIdList.Count > 0)
             {
-                this.tincanActivityId = tincanActivityIdList.Item(0).Value;
+                this.tincanActivityId = tincanActivityIdList.Item(0).FirstChild.Value;
             }
         }
 

--- a/CourseDetail.cs
+++ b/CourseDetail.cs
@@ -68,7 +68,7 @@ namespace RusticiSoftware.HostedEngine.Client
                 this.versions.Add(new CourseVersion(version));
 
             tags = new List<string>();
-            XmlNodeList tagDataList = courseDetail.GetElementsByTagName("tags");
+            XmlNodeList tagDataList = courseDetail.GetElementsByTagName("tag");
             foreach (XmlElement tag in tagDataList)
                 this.tags.Add(tag.InnerText);
 

--- a/CourseVersion.cs
+++ b/CourseVersion.cs
@@ -12,8 +12,8 @@ namespace RusticiSoftware.HostedEngine.Client
 
         public CourseVersion(XmlElement versionElement)
         {
-            this.versionId = versionElement.GetElementsByTagName("versionId").Item(0).Value;
-            this.updateDate = versionElement.GetElementsByTagName("updateDate").Item(0).Value;
+            this.versionId = versionElement.GetElementsByTagName("versionId").Item(0).FirstChild.Value;
+            this.updateDate = versionElement.GetElementsByTagName("updateDate").Item(0).FirstChild.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
The method ScormCloud.CourseService.GetCourseDetail was returning a CourseDetail object with many empty fields that should not have been.  There were a couple of issues in the code with parsing the XML returned from the service call.  First, XmlDocument.GetElementsByTagName was being used incorrectly.  The element name used was "versions" or "tags" when it should have been "version" and "tag" to get the individual elements rather than their parent element.  Then several element values were not being obtained correctly because they appeared to not account for the CDATA element.  It seems these issues could have arisen after changes to the structure of the XML response.