### PR TITLE
[ZD-42019] Fix tag parsing in CourseData

### DIFF
--- a/CourseData.cs
+++ b/CourseData.cs
@@ -58,7 +58,7 @@ namespace RusticiSoftware.HostedEngine.Client
             this.title = courseDataElement.Attributes["title"].Value;
             tags = new List<string>();
 
-            XmlNodeList tagDataList = courseDataElement.GetElementsByTagName("tags");
+            XmlNodeList tagDataList = courseDataElement.GetElementsByTagName("tag");
             foreach (XmlElement tag in tagDataList)
                 this.tags.Add(tag.InnerText);
         }


### PR DESCRIPTION
The code was walking over the list of "tags" elements and adding their
InnerText into a list. This manifested as all course tags being
concatenated into a single element in a List<string>.

This commit walks over all "tag" elements instead, which fixes the
problem.