### PR TITLE
Fix handling of urlname/urlpass in testRegistrationPostUrl

### DIFF
--- a/RegistrationService.cs
+++ b/RegistrationService.cs
@@ -640,23 +640,14 @@ namespace RusticiSoftware.HostedEngine.Client
             ServiceRequest request = new ServiceRequest(configuration);
             request.Parameters.Add("postbackurl", postbackUrl);
 
-            //Api call will fail without a placeholder username and password at least:
             if (!String.IsNullOrEmpty(urlname))
             {
-                request.Parameters.Add("name", urlname);
-            }
-            else
-            {
-                request.Parameters.Add("name", "placeholderLoginName");
+                request.Parameters.Add("urlname", urlname);
             }
 
             if (!String.IsNullOrEmpty(urlpass))
             {
-                request.Parameters.Add("password", urlpass);
-            }
-            else
-            {
-                request.Parameters.Add("password", "placeholderLoginPassword");
+                request.Parameters.Add("urlpass", urlpass);
             }
 
             request.Parameters.Add("authtype", Enum.GetName(authType.GetType(), authType).ToLower());
@@ -665,6 +656,18 @@ namespace RusticiSoftware.HostedEngine.Client
             XmlDocument response = request.CallService("rustici.registration.testRegistrationPostUrl");
             XmlElement rspElement = ((XmlElement)response.GetElementsByTagName("rsp")[0]);
             return new Rsp(rspElement);
+        }
+
+        /// <summary>
+        /// This method provides a way to test a URL for posting registration results back to, as they would be posted when using the postbackurl in the createRegistration call. When called, an example registration result will be posted to the URL given, or else an error will be reported regarding why the post failed.
+        /// </summary>
+        /// <param name="postbackUrl">Specifies a URL for which to post activity and status data in real time as the course is completed</param>
+        /// <param name="authType">Optional parameter to specify how to authorize against the given postbackurl, can be "form" or "httpbasic". If form authentication, the username and password for authentication are submitted as form fields "username" and "password", and the registration data as the form field "data". If httpbasic authentication is used, the username and password are placed in the standard Authorization HTTP header, and the registration data is the body of the message (sent as text/xml content type). This field is set to "form" by default.</param>
+        /// <param name="resultsFormat">This parameter allows you to specify a level of detail in the information that is posted back while the course is being taken. It may be one of three values: "course" (course summary), "activity" (activity summary, or "full" (full detail), and is set to "course" by default. The information will be posted as xml, and the format of that xml is specified below under the method "getRegistrationResult"</param>
+        /// <returns>Rsp containing result and status code</returns>
+        public Rsp TestRegistrationPostUrl(string postbackUrl, RegistrationResultsAuthType authType, RegistrationResultsFormat resultsFormat)
+        {
+            return TestRegistrationPostUrl(postbackUrl, authType, null, null, resultsFormat);
         }
     }
 }


### PR DESCRIPTION
The previous code used the wrong API parameter names for these
parameters, plus it would send a placeholder name if one was omitted
(even though one is not required).

This commit fixes the name problem and adds a convenience overload that
doesn't require a urlname/urlpass.